### PR TITLE
fix: resolve import sorting conflict between isort and ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
       run: |
         black --check src/ tests/
 
-    - name: Run isort import check
-      run: |
-        isort --check-only src/ tests/
-
     - name: Run Flake8 linting
       run: |
         flake8 src/ tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,6 @@ repos:
       - id: black
         language_version: python3.11
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,13 +98,15 @@ exclude_lines = [
 precision = 2
 fail_under = 80
 
-[tool.isort]
-profile = "black"
-line_length = 88
+# [tool.isort] - Deprecated: Using ruff for import sorting
+# profile = "black"
+# line_length = 88
 
 [tool.ruff]
 line-length = 88
 target-version = "py38"
+
+[tool.ruff.lint]
 select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
@@ -115,3 +117,6 @@ select = [
     "UP", # pyupgrade
 ]
 ignore = ["E203"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["obsidian_to_notion"]

--- a/tests/integration/steps/migration_orchestrator_steps.py
+++ b/tests/integration/steps/migration_orchestrator_steps.py
@@ -5,6 +5,7 @@ import tempfile
 from unittest.mock import Mock, patch
 
 from behave import given, then, when
+
 from obsidian_to_notion.config import (
     AppConfig,
     LoggingConfig,

--- a/tests/integration/steps/notion_client_steps.py
+++ b/tests/integration/steps/notion_client_steps.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 from behave import given, then, when
 from notion_client import APIResponseError
+
 from obsidian_to_notion.notion import DeduplicationManager, NotionMigrationClient
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -7,6 +7,7 @@ import unittest
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+
 from obsidian_to_notion.config import AppConfig
 from obsidian_to_notion.main import ObsidianToNotionMigrator, main, setup_logging
 from obsidian_to_notion.utils.error_handling import MigrationError

--- a/tests/unit/test_notion_client.py
+++ b/tests/unit/test_notion_client.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 from notion_client import APIResponseError
+
 from obsidian_to_notion.notion import DeduplicationManager, NotionMigrationClient
 
 


### PR DESCRIPTION
## Summary
- Remove isort from pre-commit hooks and CI workflow
- Configure ruff to handle all import sorting
- Fix import formatting in affected test files

## Problem Solved
This PR resolves issue #13 where isort and ruff had conflicting import sorting requirements:
- isort required blank lines between third-party and local imports
- ruff removed these blank lines

This created an impossible situation where the code couldn't satisfy both linters.

## Solution Implemented
Implemented Option A from the issue - using ruff exclusively for import sorting:
1. Removed isort from `.pre-commit-config.yaml`
2. Removed isort check from CI workflow
3. Updated ruff configuration in `pyproject.toml`:
   - Added `[tool.ruff.lint.isort]` section with proper settings
   - Migrated to new ruff configuration format (using `lint` subsection)
4. Fixed import sorting in all affected files

## Testing
- Ran `ruff check --fix` on all affected files
- Verified all pre-commit hooks pass
- Confirmed ruff handles import sorting consistently

## Files Changed
- `.pre-commit-config.yaml` - Removed isort hook
- `.github/workflows/ci.yml` - Removed isort check
- `pyproject.toml` - Updated ruff configuration
- 4 test files - Fixed import sorting

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/code)