### PR TITLE
feat: implement WikilinkConverter and ProgressTracker utilities for issue #4

### DIFF
--- a/src/obsidian_to_notion/main.py
+++ b/src/obsidian_to_notion/main.py
@@ -4,50 +4,13 @@
 import argparse
 import logging
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from .config import AppConfig
 from .notion import DeduplicationManager, NotionMigrationClient
 from .parsers import ObsidianVaultProcessor
+from .transformers import WikilinkConverter
 from .utils import MigrationError, ProgressTracker
-
-
-class WikilinkConverter:
-    """Wrapper for WikilinkConverter with additional functionality."""
-
-    def __init__(self, page_mapping: Optional[Dict[str, str]] = None) -> None:
-        """Initialize WikilinkConverter with optional page mapping."""
-        self.page_mapping: Dict[str, str] = page_mapping or {}
-        self.page_cache: Dict[str, str] = {}
-        self.broken_links: List[str] = []
-
-    def add_page_to_cache(self, title: str, page_id: str) -> None:
-        """Add a page to the cache for link resolution."""
-        self.page_cache[title.lower()] = page_id
-        self.page_mapping[title] = page_id
-
-    def convert_content(self, content: str, wikilinks: List[Dict]) -> str:
-        """Convert wikilinks in content."""
-        # For simple implementation, just return content as-is
-        # In a full implementation, this would parse and convert wikilinks
-        result = content
-        for link in wikilinks:
-            if link.get("note_name"):
-                note_name = link["note_name"]
-                if note_name.lower() in self.page_cache:
-                    # Replace with Notion link (simplified)
-                    pass
-                else:
-                    self.broken_links.append(note_name)
-        return result
-
-    def get_broken_links_report(self) -> str:
-        """Get report of broken links."""
-        if not self.broken_links:
-            return "No broken links found"
-        return f"Found {len(self.broken_links)} broken links: " + ", ".join(
-            self.broken_links
-        )
 
 
 class ObsidianToNotionMigrator:

--- a/src/obsidian_to_notion/transformers/wikilink_converter.py
+++ b/src/obsidian_to_notion/transformers/wikilink_converter.py
@@ -1,117 +1,231 @@
 """Convert Obsidian wikilinks to Notion links."""
 
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+import re
+from typing import Any, Dict, List, Optional
 
 
 class WikilinkConverter:
-    """Convert Obsidian wikilinks to Notion-compatible links."""
+    """Convert Obsidian wikilinks to Notion-compatible links.
 
-    def __init__(self, page_mapping: Dict[str, str]):
-        """Initialize converter with page mapping.
+    This class provides functionality to convert Obsidian-style wikilinks
+    ([[page]] and [[page|alias]]) to Notion page mentions or fallback text.
+    """
+
+    def __init__(self, page_mapping: Optional[Dict[str, str]] = None) -> None:
+        """Initialize WikilinkConverter with optional page mapping.
 
         Args:
-            page_mapping: Dictionary mapping Obsidian file paths to Notion page IDs
+            page_mapping: Dictionary mapping page titles to Notion page IDs
         """
-        self.page_mapping = page_mapping
+        self.page_mapping: Dict[str, str] = page_mapping or {}
+        self.page_cache: Dict[str, str] = {}
+        self.broken_links: List[str] = []
 
-    def convert_content(
-        self, content: str, links: List[Tuple[str, str]], current_file: Path
-    ) -> str:
+    def add_page_to_cache(self, title: str, page_id: str) -> None:
+        """Add a page to the cache for link resolution.
+
+        Args:
+            title: Page title
+            page_id: Notion page ID
+        """
+        normalized_title = title.lower().strip()
+        self.page_cache[normalized_title] = page_id
+        self.page_mapping[title] = page_id
+
+    def convert_content(self, content: str, wikilinks: List[Dict[str, Any]]) -> str:
         """Convert wikilinks in content to Notion links.
 
         Args:
             content: Original markdown content
-            links: List of (full_match, link_text) tuples
-            current_file: Path of the current file being processed
+            wikilinks: List of wikilink dictionaries with 'note_name' and optional 'alias'
 
         Returns:
             Content with converted links
         """
-        converted = content
+        converted_content = content
 
-        for full_match, link_text in links:
-            notion_link = self.convert_wikilink(link_text, current_file)
-            if notion_link:
-                converted = converted.replace(full_match, notion_link)
+        for link_info in wikilinks:
+            note_name = link_info.get("note_name", "")
+            alias = link_info.get("alias")
+            section = link_info.get("section")
 
-        return converted
+            if not note_name:
+                continue
 
-    def convert_wikilink(self, link_text: str, current_file: Path) -> Optional[str]:
+            # Find the original wikilink pattern in content
+            original_link = self._find_original_link(content, note_name, alias, section)
+            if not original_link:
+                continue
+
+            # Convert to Notion format
+            notion_link = self._convert_wikilink_to_notion(note_name, alias, section)
+
+            # Replace in content
+            converted_content = converted_content.replace(original_link, notion_link)
+
+        return converted_content
+
+    def _find_original_link(
+        self,
+        content: str,
+        note_name: str,
+        alias: Optional[str] = None,
+        section: Optional[str] = None,
+    ) -> Optional[str]:
+        """Find the original wikilink pattern in content.
+
+        Args:
+            content: Content to search in
+            note_name: Note name from wikilink
+            alias: Optional alias
+            section: Optional section reference
+
+        Returns:
+            Original wikilink string if found
+        """
+        # Build possible patterns
+        patterns = []
+
+        if alias:
+            if section:
+                patterns.append(f"[[{note_name}#{section}|{alias}]]")
+            patterns.append(f"[[{note_name}|{alias}]]")
+
+        if section:
+            patterns.append(f"[[{note_name}#{section}]]")
+
+        patterns.append(f"[[{note_name}]]")
+
+        # Check each pattern
+        for pattern in patterns:
+            if pattern in content:
+                return pattern
+
+        return None
+
+    def _convert_wikilink_to_notion(
+        self, note_name: str, alias: Optional[str] = None, section: Optional[str] = None
+    ) -> str:
         """Convert a single wikilink to Notion format.
 
         Args:
-            link_text: Text inside the wikilink
-            current_file: Path of the file containing the link
+            note_name: Name of the note being linked to
+            alias: Optional display alias
+            section: Optional section reference
 
         Returns:
-            Notion-formatted link or None if target not found
+            Notion-formatted link or fallback text
         """
-        # Parse link components
-        alias = None
-        section = None
+        normalized_name = note_name.lower().strip()
+        display_text = alias or note_name
 
-        # Handle aliases
-        if "|" in link_text:
-            link_path, alias = link_text.split("|", 1)
+        # Add section to display text if present
+        if section and not alias:
+            display_text = f"{note_name}#{section}"
+        elif section and alias:
+            display_text = f"{alias} (#{section})"
+
+        # Check if we have a Notion page ID for this note
+        page_id = self.page_cache.get(normalized_name) or self.page_mapping.get(
+            note_name
+        )
+
+        if page_id:
+            # Create Notion page mention link
+            # Note: This creates a markdown link that can be converted to Notion blocks
+            return f"[{display_text}](@{page_id})"
         else:
-            link_path = link_text
+            # Track broken link
+            broken_link = f"{note_name}#{section}" if section else note_name
+            if broken_link not in self.broken_links:
+                self.broken_links.append(broken_link)
 
-        # Handle section links
-        if "#" in link_path:
-            parts = link_path.split("#", 1)
-            link_path = parts[0]
-            section = parts[1] if len(parts) > 1 else None
+            # Return as plain text with indicator
+            return f"{display_text} (link not found)"
 
-        # Determine display text
-        display_text = alias or link_path or current_file.stem
-
-        # If it's a same-file section link
-        if not link_path:
-            # For now, just return the display text
-            # TODO: Handle section anchors when Notion API supports them
-            return f"[{display_text}](#{section})" if section else display_text
-
-        # Look up Notion page ID
-        notion_page_id = self.page_mapping.get(link_path)
-        if not notion_page_id:
-            # Return as plain text if page not found
-            return f"{display_text} (page not found)"
-
-        # Format as Notion mention
-        return self.format_notion_mention(notion_page_id, display_text)
-
-    def format_notion_mention(self, page_id: str, display_text: str) -> str:
-        """Format a Notion page mention.
-
-        Args:
-            page_id: Notion page ID
-            display_text: Text to display
+    def get_broken_links_report(self) -> str:
+        """Get report of broken links found during conversion.
 
         Returns:
-            Formatted mention
+            Human-readable report of broken links
         """
-        # Notion uses a special format for page mentions in markdown
-        # For API, we'll need to use block format
-        return f"[{display_text}](notion://www.notion.so/{page_id.replace('-', '')})"
+        if not self.broken_links:
+            return "No broken links found"
 
-    def create_mention_block(self, page_id: str) -> Dict:
-        """Create a Notion mention block.
+        report_lines = [f"Found {len(self.broken_links)} broken links:", ""]
+
+        for link in sorted(set(self.broken_links)):
+            report_lines.append(f"  - {link}")
+
+        return "\n".join(report_lines)
+
+    def create_mention_rich_text(
+        self, page_id: str, display_text: str
+    ) -> Dict[str, Any]:
+        """Create a Notion rich text mention object.
 
         Args:
             page_id: Notion page ID to mention
+            display_text: Text to display for the mention
 
         Returns:
-            Notion block object
+            Notion rich text mention object
         """
         return {
-            "type": "paragraph",
-            "paragraph": {
-                "rich_text": [
-                    {
-                        "type": "mention",
-                        "mention": {"type": "page", "page": {"id": page_id}},
-                    }
-                ]
+            "type": "mention",
+            "mention": {"type": "page", "page": {"id": page_id}},
+            "annotations": {
+                "bold": False,
+                "italic": False,
+                "strikethrough": False,
+                "underline": False,
+                "code": False,
+                "color": "default",
             },
+            "plain_text": display_text,
+            "href": f"https://www.notion.so/{page_id.replace('-', '')}",
         }
+
+    def parse_notion_link_from_content(self, content: str) -> List[Dict[str, Any]]:
+        """Parse converted Notion links from content to create rich text objects.
+
+        Args:
+            content: Content containing converted Notion links
+
+        Returns:
+            List of rich text objects for Notion API
+        """
+        rich_text = []
+
+        # Pattern to match our converted links: [display_text](@page_id)
+        link_pattern = r"\[([^\]]+)\]\(@([^)]+)\)"
+
+        last_end = 0
+
+        for match in re.finditer(link_pattern, content):
+            start, end = match.span()
+            display_text = match.group(1)
+            page_id = match.group(2)
+
+            # Add text before the link
+            if start > last_end:
+                text_before = content[last_end:start]
+                if text_before:
+                    rich_text.append({"type": "text", "text": {"content": text_before}})
+
+            # Add the mention
+            rich_text.append(self.create_mention_rich_text(page_id, display_text))
+
+            last_end = end
+
+        # Add remaining text
+        if last_end < len(content):
+            remaining_text = content[last_end:]
+            if remaining_text:
+                rich_text.append({"type": "text", "text": {"content": remaining_text}})
+
+        # If no links found, return the whole content as text
+        if not rich_text:
+            rich_text = [{"type": "text", "text": {"content": content}}]
+
+        return rich_text

--- a/src/obsidian_to_notion/transformers/wikilink_converter.py
+++ b/src/obsidian_to_notion/transformers/wikilink_converter.py
@@ -37,7 +37,8 @@ class WikilinkConverter:
 
         Args:
             content: Original markdown content
-            wikilinks: List of wikilink dictionaries with 'note_name' and optional 'alias'
+            wikilinks: List of wikilink dictionaries with 'note_name' and optional
+                'alias'
 
         Returns:
             Content with converted links

--- a/src/obsidian_to_notion/utils/__init__.py
+++ b/src/obsidian_to_notion/utils/__init__.py
@@ -1,6 +1,24 @@
 """Utility modules for Obsidian to Notion migration."""
 
-from .error_handling import MigrationError
-from .progress import ProgressReporter as ProgressTracker
+from .error_handling import (
+    ConfigError,
+    MigrationError,
+    NotionAPIError,
+    ParseError,
+    retry_on_api_error,
+    safe_file_operation,
+    setup_error_handling,
+)
+from .progress import ProgressReporter, ProgressTracker
 
-__all__ = ["MigrationError", "ProgressTracker"]
+__all__ = [
+    "MigrationError",
+    "ConfigError",
+    "NotionAPIError",
+    "ParseError",
+    "ProgressReporter",
+    "ProgressTracker",
+    "retry_on_api_error",
+    "safe_file_operation",
+    "setup_error_handling",
+]

--- a/src/obsidian_to_notion/utils/progress.py
+++ b/src/obsidian_to_notion/utils/progress.py
@@ -1,8 +1,96 @@
 """Progress reporting utilities."""
 
-from typing import Optional
+from typing import Any, Optional
 
 from tqdm import tqdm  # type: ignore[import-untyped]
+
+
+class ProgressTracker:
+    """Context manager-enabled progress tracker for migration operations.
+
+    This class provides progress tracking capabilities with support for
+    nested progress bars and context manager usage.
+    """
+
+    def __init__(self) -> None:
+        """Initialize progress tracker."""
+        self.main_progress: Optional[tqdm] = None
+        self.sub_progress: Optional[tqdm] = None
+
+    def __enter__(self) -> "ProgressTracker":
+        """Enter context manager."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit context manager and clean up progress bars."""
+        self.close()
+
+    def start_main(self, total: int, desc: str = "Processing") -> None:
+        """Start main progress bar.
+
+        Args:
+            total: Total number of items
+            desc: Description for progress bar
+        """
+        self.main_progress = tqdm(total=total, desc=desc, position=0)
+
+    def start_sub(self, total: int, desc: str = "Current file") -> None:
+        """Start sub progress bar.
+
+        Args:
+            total: Total number of items
+            desc: Description for progress bar
+        """
+        self.sub_progress = tqdm(total=total, desc=desc, position=1, leave=False)
+
+    def update_main(self, n: int = 1) -> None:
+        """Update main progress bar.
+
+        Args:
+            n: Number of items completed
+        """
+        if self.main_progress:
+            self.main_progress.update(n)
+
+    def update_sub(self, n: int = 1) -> None:
+        """Update sub progress bar.
+
+        Args:
+            n: Number of items completed
+        """
+        if self.sub_progress:
+            self.sub_progress.update(n)
+
+    def set_main_desc(self, desc: str) -> None:
+        """Update main progress bar description.
+
+        Args:
+            desc: New description
+        """
+        if self.main_progress:
+            self.main_progress.set_description(desc)
+
+    def set_sub_desc(self, desc: str) -> None:
+        """Update sub progress bar description.
+
+        Args:
+            desc: New description
+        """
+        if self.sub_progress:
+            self.sub_progress.set_description(desc)
+
+    def close_sub(self) -> None:
+        """Close sub progress bar."""
+        if self.sub_progress:
+            self.sub_progress.close()
+            self.sub_progress = None
+
+    def close(self) -> None:
+        """Close all progress bars."""
+        self.close_sub()
+        if self.main_progress:
+            self.main_progress.close()
+            self.main_progress = None
 
 
 class ProgressReporter:

--- a/tests/integration/features/wikilink_converter.feature
+++ b/tests/integration/features/wikilink_converter.feature
@@ -1,0 +1,64 @@
+Feature: Wikilink Converter
+  As a user migrating from Obsidian to Notion
+  I want my wikilinks to be converted to Notion page mentions
+  So that my document relationships are preserved
+
+  Scenario: Convert basic wikilinks
+    Given I have a WikilinkConverter instance
+    When I add pages to the cache
+      | title      | page_id    |
+      | Test Page  | page-123   |
+      | Notes      | page-456   |
+    And I convert content with wikilinks
+      | content                               | wikilinks                           |
+      | Check out [[Test Page]] for details   | [{"note_name": "Test Page"}]        |
+    Then the content should contain Notion links
+    And no broken links should be reported
+
+  Scenario: Convert wikilinks with aliases
+    Given I have a WikilinkConverter instance
+    When I add pages to the cache
+      | title      | page_id    |
+      | Test Page  | page-123   |
+    And I convert content with wikilinks
+      | content                                    | wikilinks                                                    |
+      | See [[Test Page\|my custom link]] here    | [{"note_name": "Test Page", "alias": "my custom link"}]     |
+    Then the content should contain "[my custom link](@page-123)"
+    And no broken links should be reported
+
+  Scenario: Handle broken wikilinks
+    Given I have a WikilinkConverter instance
+    When I convert content with wikilinks
+      | content                                  | wikilinks                              |
+      | This links to [[Unknown Page]] here     | [{"note_name": "Unknown Page"}]       |
+    Then the content should contain "(link not found)"
+    And broken links should be reported
+
+  Scenario: Convert wikilinks with sections
+    Given I have a WikilinkConverter instance
+    When I add pages to the cache
+      | title      | page_id    |
+      | Test Page  | page-123   |
+    And I convert content with wikilinks
+      | content                                       | wikilinks                                                        |
+      | See [[Test Page#Introduction]] for details   | [{"note_name": "Test Page", "section": "Introduction"}]         |
+    Then the content should contain "[Test Page#Introduction](@page-123)"
+    And no broken links should be reported
+
+  Scenario: Generate broken links report
+    Given I have a WikilinkConverter instance
+    When I convert content with broken wikilinks
+      | content                              | wikilinks                           |
+      | Link to [[Missing Page]]             | [{"note_name": "Missing Page"}]    |
+      | Another [[Gone Page]] reference      | [{"note_name": "Gone Page"}]       |
+    Then the broken links report should list all missing pages
+
+  Scenario: Parse content with mixed links
+    Given I have a WikilinkConverter instance with cached pages
+    When I parse content "[Valid Page](@page-123) and [Another](@page-456)"
+    Then I should get rich text objects with mentions and text
+
+  Scenario: Create Notion mention rich text
+    Given I have a WikilinkConverter instance
+    When I create a mention for page "page-123" with text "Test Page"
+    Then I should get a valid Notion mention object

--- a/tests/integration/steps/wikilink_converter_steps.py
+++ b/tests/integration/steps/wikilink_converter_steps.py
@@ -1,0 +1,160 @@
+"""Step definitions for WikilinkConverter integration tests."""
+
+import json
+
+from behave import given, then, when
+
+from obsidian_to_notion.transformers.wikilink_converter import WikilinkConverter
+
+
+@given("I have a WikilinkConverter instance")
+def step_create_wikilink_converter(context):
+    """Create a WikilinkConverter instance."""
+    context.converter = WikilinkConverter()
+
+
+@given("I have a WikilinkConverter instance with cached pages")
+def step_create_converter_with_cache(context):
+    """Create a WikilinkConverter instance with some cached pages."""
+    context.converter = WikilinkConverter()
+    context.converter.add_page_to_cache("Valid Page", "page-123")
+    context.converter.add_page_to_cache("Another", "page-456")
+
+
+@when("I add pages to the cache")
+def step_add_pages_to_cache(context):
+    """Add pages to the converter cache."""
+    for row in context.table:
+        context.converter.add_page_to_cache(row["title"], row["page_id"])
+
+
+@when("I convert content with wikilinks")
+def step_convert_content_with_wikilinks(context):
+    """Convert content with wikilinks."""
+    context.results = []
+
+    for row in context.table:
+        content = row["content"]
+        wikilinks_json = row["wikilinks"]
+
+        # Parse the JSON string to get wikilinks list
+        wikilinks = json.loads(wikilinks_json)
+
+        result = context.converter.convert_content(content, wikilinks)
+        context.results.append(
+            {"original": content, "converted": result, "wikilinks": wikilinks}
+        )
+
+
+@when("I convert content with broken wikilinks")
+def step_convert_content_with_broken_wikilinks(context):
+    """Convert content with broken wikilinks."""
+    context.results = []
+
+    for row in context.table:
+        content = row["content"]
+        wikilinks_json = row["wikilinks"]
+
+        wikilinks = json.loads(wikilinks_json)
+        result = context.converter.convert_content(content, wikilinks)
+
+        context.results.append(
+            {"original": content, "converted": result, "wikilinks": wikilinks}
+        )
+
+
+@when('I parse content "{content}"')
+def step_parse_content(context, content):
+    """Parse content to get rich text objects."""
+    context.parsed_result = context.converter.parse_notion_link_from_content(content)
+
+
+@when('I create a mention for page "{page_id}" with text "{text}"')
+def step_create_mention(context, page_id, text):
+    """Create a Notion mention rich text object."""
+    context.mention_result = context.converter.create_mention_rich_text(page_id, text)
+
+
+@then("the content should contain Notion links")
+def step_verify_notion_links(context):
+    """Verify content contains Notion-formatted links."""
+    for result in context.results:
+        converted = result["converted"]
+        # Should contain the @page-id format
+        assert "@page-" in converted, f"No Notion links found in: {converted}"
+
+
+@then('the content should contain "{expected_text}"')
+def step_verify_content_contains(context, expected_text):
+    """Verify content contains specific text."""
+    for result in context.results:
+        converted = result["converted"]
+        assert (
+            expected_text in converted
+        ), f"Expected '{expected_text}' not found in: {converted}"
+
+
+@then("no broken links should be reported")
+def step_verify_no_broken_links(context):
+    """Verify no broken links were reported."""
+    report = context.converter.get_broken_links_report()
+    assert "No broken links found" in report, f"Unexpected broken links: {report}"
+
+
+@then("broken links should be reported")
+def step_verify_broken_links_reported(context):
+    """Verify broken links were reported."""
+    report = context.converter.get_broken_links_report()
+    assert (
+        "No broken links found" not in report
+    ), "Expected broken links but none were reported"
+    assert len(context.converter.broken_links) > 0, "No broken links in the list"
+
+
+@then("the broken links report should list all missing pages")
+def step_verify_broken_links_report(context):
+    """Verify broken links report contains all missing pages."""
+    report = context.converter.get_broken_links_report()
+
+    # Extract expected missing pages from the test data
+    expected_missing = set()
+    for result in context.results:
+        for link in result["wikilinks"]:
+            expected_missing.add(link["note_name"])
+
+    # Verify all missing pages are in the report
+    for missing_page in expected_missing:
+        assert (
+            missing_page in report
+        ), f"Missing page '{missing_page}' not in report: {report}"
+
+
+@then("I should get rich text objects with mentions and text")
+def step_verify_rich_text_objects(context):
+    """Verify parsed result contains rich text objects."""
+    result = context.parsed_result
+
+    assert isinstance(result, list), "Result should be a list"
+    assert len(result) > 0, "Result should not be empty"
+
+    # Should have both text and mention objects
+    has_text = any(obj.get("type") == "text" for obj in result)
+    has_mention = any(obj.get("type") == "mention" for obj in result)
+
+    assert has_text, "Should contain text objects"
+    assert has_mention, "Should contain mention objects"
+
+
+@then("I should get a valid Notion mention object")
+def step_verify_mention_object(context):
+    """Verify mention object structure."""
+    mention = context.mention_result
+
+    assert mention["type"] == "mention", "Should be a mention type"
+    assert "mention" in mention, "Should have mention property"
+    assert mention["mention"]["type"] == "page", "Should be a page mention"
+    assert "page" in mention["mention"], "Should have page property"
+    assert "id" in mention["mention"]["page"], "Should have page ID"
+    assert "annotations" in mention, "Should have annotations"
+    assert "plain_text" in mention, "Should have plain_text"
+    assert "href" in mention, "Should have href"

--- a/tests/unit/test_progress_tracker.py
+++ b/tests/unit/test_progress_tracker.py
@@ -1,0 +1,182 @@
+"""Unit tests for ProgressTracker class."""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from obsidian_to_notion.utils.progress import ProgressTracker
+
+
+class TestProgressTracker(unittest.TestCase):
+    """Test ProgressTracker class."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.tracker = ProgressTracker()
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_init(self, mock_tqdm: Mock) -> None:
+        """Test ProgressTracker initialization."""
+        tracker = ProgressTracker()
+        self.assertIsNone(tracker.main_progress)
+        self.assertIsNone(tracker.sub_progress)
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_context_manager(self, mock_tqdm: Mock) -> None:
+        """Test ProgressTracker as context manager."""
+        mock_progress = Mock()
+        mock_tqdm.return_value = mock_progress
+
+        with ProgressTracker() as tracker:
+            tracker.start_main(100, "Test")
+            self.assertIsNotNone(tracker.main_progress)
+
+        # Should have closed progress bars
+        mock_progress.close.assert_called()
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_context_manager_with_exception(self, mock_tqdm: Mock) -> None:
+        """Test ProgressTracker context manager with exception."""
+        mock_progress = Mock()
+        mock_tqdm.return_value = mock_progress
+
+        try:
+            with ProgressTracker() as tracker:
+                tracker.start_main(100, "Test")
+                raise ValueError("Test error")
+        except ValueError:
+            pass
+
+        # Should still close progress bars on exception
+        mock_progress.close.assert_called()
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_start_main(self, mock_tqdm: Mock) -> None:
+        """Test starting main progress bar."""
+        mock_progress = Mock()
+        mock_tqdm.return_value = mock_progress
+
+        self.tracker.start_main(100, "Processing files")
+
+        mock_tqdm.assert_called_once_with(
+            total=100, desc="Processing files", position=0
+        )
+        self.assertEqual(self.tracker.main_progress, mock_progress)
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_start_sub(self, mock_tqdm: Mock) -> None:
+        """Test starting sub progress bar."""
+        mock_progress = Mock()
+        mock_tqdm.return_value = mock_progress
+
+        self.tracker.start_sub(50, "Current file")
+
+        mock_tqdm.assert_called_once_with(
+            total=50, desc="Current file", position=1, leave=False
+        )
+        self.assertEqual(self.tracker.sub_progress, mock_progress)
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_update_main(self, mock_tqdm: Mock) -> None:
+        """Test updating main progress bar."""
+        mock_progress = Mock()
+        mock_tqdm.return_value = mock_progress
+
+        self.tracker.start_main(100, "Test")
+        self.tracker.update_main(5)
+
+        mock_progress.update.assert_called_once_with(5)
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_update_main_no_progress(self, mock_tqdm: Mock) -> None:
+        """Test updating main progress bar when none exists."""
+        # Should not raise error
+        self.tracker.update_main(5)
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_update_sub(self, mock_tqdm: Mock) -> None:
+        """Test updating sub progress bar."""
+        mock_progress = Mock()
+        mock_tqdm.return_value = mock_progress
+
+        self.tracker.start_sub(50, "Test")
+        self.tracker.update_sub(3)
+
+        mock_progress.update.assert_called_once_with(3)
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_update_sub_no_progress(self, mock_tqdm: Mock) -> None:
+        """Test updating sub progress bar when none exists."""
+        # Should not raise error
+        self.tracker.update_sub(3)
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_set_main_desc(self, mock_tqdm: Mock) -> None:
+        """Test setting main progress bar description."""
+        mock_progress = Mock()
+        mock_tqdm.return_value = mock_progress
+
+        self.tracker.start_main(100, "Test")
+        self.tracker.set_main_desc("New description")
+
+        mock_progress.set_description.assert_called_once_with("New description")
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_set_main_desc_no_progress(self, mock_tqdm: Mock) -> None:
+        """Test setting main progress bar description when none exists."""
+        # Should not raise error
+        self.tracker.set_main_desc("New description")
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_set_sub_desc(self, mock_tqdm: Mock) -> None:
+        """Test setting sub progress bar description."""
+        mock_progress = Mock()
+        mock_tqdm.return_value = mock_progress
+
+        self.tracker.start_sub(50, "Test")
+        self.tracker.set_sub_desc("New description")
+
+        mock_progress.set_description.assert_called_once_with("New description")
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_set_sub_desc_no_progress(self, mock_tqdm: Mock) -> None:
+        """Test setting sub progress bar description when none exists."""
+        # Should not raise error
+        self.tracker.set_sub_desc("New description")
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_close_sub(self, mock_tqdm: Mock) -> None:
+        """Test closing sub progress bar."""
+        mock_progress = Mock()
+        mock_tqdm.return_value = mock_progress
+
+        self.tracker.start_sub(50, "Test")
+        self.tracker.close_sub()
+
+        mock_progress.close.assert_called_once()
+        self.assertIsNone(self.tracker.sub_progress)
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_close_sub_no_progress(self, mock_tqdm: Mock) -> None:
+        """Test closing sub progress bar when none exists."""
+        # Should not raise error
+        self.tracker.close_sub()
+
+    @patch("obsidian_to_notion.utils.progress.tqdm")
+    def test_close(self, mock_tqdm: Mock) -> None:
+        """Test closing all progress bars."""
+        mock_main = Mock()
+        mock_sub = Mock()
+        mock_tqdm.side_effect = [mock_main, mock_sub]
+
+        self.tracker.start_main(100, "Main")
+        self.tracker.start_sub(50, "Sub")
+        self.tracker.close()
+
+        mock_main.close.assert_called_once()
+        mock_sub.close.assert_called_once()
+        self.assertIsNone(self.tracker.main_progress)
+        self.assertIsNone(self.tracker.sub_progress)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_wikilink_converter_new.py
+++ b/tests/unit/test_wikilink_converter_new.py
@@ -1,0 +1,178 @@
+"""Unit tests for the updated WikilinkConverter implementation."""
+
+import unittest
+from typing import Any, Dict, List
+
+from obsidian_to_notion.transformers.wikilink_converter import WikilinkConverter
+
+
+class TestWikilinkConverterNew(unittest.TestCase):
+    """Test the updated WikilinkConverter class."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.converter = WikilinkConverter()
+
+        # Add some test pages to cache
+        self.converter.add_page_to_cache("Test Page", "page-123")
+        self.converter.add_page_to_cache("Another Note", "page-456")
+
+    def test_init_with_no_mapping(self) -> None:
+        """Test initialization without page mapping."""
+        converter = WikilinkConverter()
+        self.assertEqual(converter.page_mapping, {})
+        self.assertEqual(converter.page_cache, {})
+        self.assertEqual(converter.broken_links, [])
+
+    def test_init_with_mapping(self) -> None:
+        """Test initialization with page mapping."""
+        mapping = {"Page A": "page-a", "Page B": "page-b"}
+        converter = WikilinkConverter(mapping)
+        self.assertEqual(converter.page_mapping, mapping)
+        self.assertEqual(converter.page_cache, {})
+        self.assertEqual(converter.broken_links, [])
+
+    def test_add_page_to_cache(self) -> None:
+        """Test adding page to cache."""
+        converter = WikilinkConverter()
+        converter.add_page_to_cache("New Page", "page-789")
+
+        self.assertEqual(converter.page_cache["new page"], "page-789")
+        self.assertEqual(converter.page_mapping["New Page"], "page-789")
+
+    def test_convert_content_no_links(self) -> None:
+        """Test converting content with no wikilinks."""
+        content = "This is just plain text without any links."
+        wikilinks: List[Dict[str, Any]] = []
+
+        result = self.converter.convert_content(content, wikilinks)
+        self.assertEqual(result, content)
+
+    def test_convert_content_with_valid_link(self) -> None:
+        """Test converting content with valid wikilink."""
+        content = "Check out [[Test Page]] for more info."
+        wikilinks = [{"note_name": "Test Page"}]
+
+        result = self.converter.convert_content(content, wikilinks)
+        self.assertIn("[Test Page](@page-123)", result)
+        self.assertNotIn("[[Test Page]]", result)
+
+    def test_convert_content_with_alias(self) -> None:
+        """Test converting content with wikilink alias."""
+        content = "See [[Test Page|my custom link]] here."
+        wikilinks = [{"note_name": "Test Page", "alias": "my custom link"}]
+
+        result = self.converter.convert_content(content, wikilinks)
+        self.assertIn("[my custom link](@page-123)", result)
+
+    def test_convert_content_with_broken_link(self) -> None:
+        """Test converting content with broken wikilink."""
+        content = "This links to [[Unknown Page]] which doesn't exist."
+        wikilinks = [{"note_name": "Unknown Page"}]
+
+        result = self.converter.convert_content(content, wikilinks)
+        self.assertIn("Unknown Page (link not found)", result)
+        self.assertIn("Unknown Page", self.converter.broken_links)
+
+    def test_convert_content_with_section_link(self) -> None:
+        """Test converting content with section link."""
+        content = "See [[Test Page#Introduction]] for details."
+        wikilinks = [{"note_name": "Test Page", "section": "Introduction"}]
+
+        result = self.converter.convert_content(content, wikilinks)
+        self.assertIn("[Test Page#Introduction](@page-123)", result)
+
+    def test_get_broken_links_report_none(self) -> None:
+        """Test broken links report when no broken links."""
+        report = self.converter.get_broken_links_report()
+        self.assertEqual(report, "No broken links found")
+
+    def test_get_broken_links_report_with_links(self) -> None:
+        """Test broken links report with broken links."""
+        # Add some broken links
+        self.converter.broken_links = [
+            "Missing Page",
+            "Another Missing",
+            "Missing Page",
+        ]
+
+        report = self.converter.get_broken_links_report()
+        self.assertIn("Found 3 broken links:", report)
+        self.assertIn("- Another Missing", report)
+        self.assertIn("- Missing Page", report)
+
+    def test_create_mention_rich_text(self) -> None:
+        """Test creating Notion mention rich text object."""
+        result = self.converter.create_mention_rich_text("page-123", "Test Page")
+
+        expected = {
+            "type": "mention",
+            "mention": {"type": "page", "page": {"id": "page-123"}},
+            "annotations": {
+                "bold": False,
+                "italic": False,
+                "strikethrough": False,
+                "underline": False,
+                "code": False,
+                "color": "default",
+            },
+            "plain_text": "Test Page",
+            "href": "https://www.notion.so/page123",
+        }
+
+        self.assertEqual(result, expected)
+
+    def test_parse_notion_link_from_content_no_links(self) -> None:
+        """Test parsing content with no Notion links."""
+        content = "Just plain text here."
+        result = self.converter.parse_notion_link_from_content(content)
+
+        expected = [{"type": "text", "text": {"content": "Just plain text here."}}]
+        self.assertEqual(result, expected)
+
+    def test_parse_notion_link_from_content_with_links(self) -> None:
+        """Test parsing content with Notion links."""
+        content = "Check out [Test Page](@page-123) and [Another](@page-456) for info."
+        result = self.converter.parse_notion_link_from_content(content)
+
+        self.assertEqual(len(result), 5)  # text, mention, text, mention, text
+        self.assertEqual(result[0]["type"], "text")
+        self.assertEqual(result[1]["type"], "mention")
+        self.assertEqual(result[2]["type"], "text")
+        self.assertEqual(result[3]["type"], "mention")
+        self.assertEqual(result[4]["type"], "text")
+
+    def test_find_original_link_basic(self) -> None:
+        """Test finding original wikilink in content."""
+        content = "This has [[Test Page]] in it."
+        result = self.converter._find_original_link(content, "Test Page")
+        self.assertEqual(result, "[[Test Page]]")
+
+    def test_find_original_link_with_alias(self) -> None:
+        """Test finding original wikilink with alias."""
+        content = "This has [[Test Page|custom text]] in it."
+        result = self.converter._find_original_link(
+            content, "Test Page", alias="custom text"
+        )
+        self.assertEqual(result, "[[Test Page|custom text]]")
+
+    def test_find_original_link_not_found(self) -> None:
+        """Test finding original wikilink when not found."""
+        content = "This has no links."
+        result = self.converter._find_original_link(content, "Test Page")
+        self.assertIsNone(result)
+
+    def test_convert_wikilink_to_notion_found(self) -> None:
+        """Test converting wikilink to Notion format when found."""
+        result = self.converter._convert_wikilink_to_notion("Test Page")
+        self.assertEqual(result, "[Test Page](@page-123)")
+
+    def test_convert_wikilink_to_notion_not_found(self) -> None:
+        """Test converting wikilink to Notion format when not found."""
+        result = self.converter._convert_wikilink_to_notion("Unknown Page")
+        self.assertEqual(result, "Unknown Page (link not found)")
+        self.assertIn("Unknown Page", self.converter.broken_links)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements the missing utility modules required for the Obsidian to Notion migration as specified in issue #4:

### WikilinkConverter
- ✅ Convert Obsidian `[[wikilinks]]` to Notion page mentions
- ✅ Support for aliases: `[[page|alias]]` and sections: `[[page#section]]`
- ✅ Track broken links and generate comprehensive reports
- ✅ Parse converted content to create Notion rich text objects
- ✅ Compatible with main.py interface requirements

### ProgressTracker
- ✅ Context manager-enabled progress tracking with tqdm
- ✅ Support for nested progress bars (main and sub)
- ✅ Safe cleanup on exceptions via context manager protocol
- ✅ Compatible with existing ProgressReporter interface

### Code Quality & Testing
- ✅ Updated main.py to use proper WikilinkConverter import
- ✅ Enhanced utils module exports for better organization
- ✅ Added comprehensive unit tests (34 tests, all passing)
- ✅ Added integration tests with Behave/Gherkin (7 scenarios, all passing)
- ✅ All new functionality fully covered by tests
- ✅ Existing main module imports and basic functionality verified

## Test Results
```
Unit Tests: 34/34 passing
Integration Tests: 7/7 scenarios passing
Main module import: ✅ successful
```

## Files Changed
- `src/obsidian_to_notion/transformers/wikilink_converter.py` - Complete implementation
- `src/obsidian_to_notion/utils/progress.py` - Added ProgressTracker class
- `src/obsidian_to_notion/utils/__init__.py` - Enhanced exports
- `src/obsidian_to_notion/main.py` - Updated to use proper imports
- `tests/unit/test_wikilink_converter_new.py` - Comprehensive unit tests
- `tests/unit/test_progress_tracker.py` - ProgressTracker unit tests
- `tests/integration/features/wikilink_converter.feature` - BDD scenarios
- `tests/integration/steps/wikilink_converter_steps.py` - Step definitions

🤖 Generated with [Claude Code](https://claude.ai/code)