### PR TITLE
fix: update README to use python3 instead of python

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Python utility to migrate Obsidian markdown files to Notion databases, handlin
 ## Setup
 
 1. Clone/download this project
-2. Create virtual environment: `python -m venv .venv`
+2. Create virtual environment: `python3 -m venv .venv`
 3. Activate it: `source .venv/bin/activate` (Linux/Mac) or `.venv\Scripts\activate` (Windows)
 4. Install dependencies: `pip install -r requirements.txt`
 5. Copy `.env.example` to `.env` and fill in your Notion API credentials
@@ -15,13 +15,13 @@ A Python utility to migrate Obsidian markdown files to Notion databases, handlin
 
 ```bash
 # Dry run to see what would be migrated
-python migrate.py --dry-run
+python3 migrate.py --dry-run
 
 # Actual migration
-python migrate.py
+python3 migrate.py
 
 # Custom config file
-python migrate.py --config my-config.yaml
+python3 migrate.py --config my-config.yaml
 ```
 
 ## Configuration

--- a/tests/integration/features/readme_documentation.feature
+++ b/tests/integration/features/readme_documentation.feature
@@ -1,0 +1,25 @@
+Feature: README Documentation
+  As a developer
+  I want the README to have correct Python command examples
+  So that I can successfully set up and run the project
+
+  Scenario: README uses python3 command for virtual environment setup
+    Given I have the README.md file
+    When I look for virtual environment setup instructions
+    Then the command should use "python3" not "python"
+
+  Scenario: README uses python3 command for dry-run example
+    Given I have the README.md file
+    When I look for dry-run command examples
+    Then the command should use "python3" not "python"
+
+  Scenario: README uses python3 command for migration execution
+    Given I have the README.md file
+    When I look for migration execution examples
+    Then the command should use "python3" not "python"
+
+  Scenario: All Python commands in README use python3
+    Given I have the README.md file
+    When I search for all Python command examples
+    Then all commands should use "python3" not "python"
+    And there should be no instances of "python " without the "3"

--- a/tests/integration/steps/readme_documentation_steps.py
+++ b/tests/integration/steps/readme_documentation_steps.py
@@ -1,0 +1,103 @@
+"""Step definitions for README documentation tests."""
+
+import re
+from pathlib import Path
+
+from behave import given, then, when
+
+
+@given("I have the README.md file")
+def step_have_readme_file(context):
+    """Ensure README.md exists and load its content."""
+    # Look for README.md in project root
+    readme_path = Path("../../README.md")
+    if not readme_path.exists():
+        # Try from project root if running from there
+        readme_path = Path("README.md")
+    assert readme_path.exists(), f"README.md file not found at {readme_path.absolute()}"
+    context.readme_content = readme_path.read_text()
+    context.readme_lines = context.readme_content.splitlines()
+
+
+@when("I look for virtual environment setup instructions")
+def step_look_for_venv_setup(context):
+    """Find virtual environment setup command in README."""
+    context.venv_commands = []
+    for i, line in enumerate(context.readme_lines):
+        if "venv" in line and "-m" in line:
+            context.venv_commands.append((i + 1, line))
+
+
+@when("I look for dry-run command examples")
+def step_look_for_dry_run(context):
+    """Find dry-run command examples in README."""
+    context.dry_run_commands = []
+    for i, line in enumerate(context.readme_lines):
+        if "--dry-run" in line:
+            context.dry_run_commands.append((i + 1, line))
+
+
+@when("I look for migration execution examples")
+def step_look_for_migration_execution(context):
+    """Find migration execution command examples in README."""
+    context.migration_commands = []
+    for i, line in enumerate(context.readme_lines):
+        if "migrate.py" in line and "--dry-run" not in line:
+            context.migration_commands.append((i + 1, line))
+
+
+@when("I search for all Python command examples")
+def step_search_all_python_commands(context):
+    """Find all Python command examples in README."""
+    context.python_commands = []
+    # Look for lines that contain python commands
+    # Pattern matches 'python' followed by space or newline, but not 'python3'
+    pattern = r"\bpython(?!3)\s"
+    for i, line in enumerate(context.readme_lines):
+        if re.search(pattern, line):
+            context.python_commands.append((i + 1, line))
+
+
+@then('the command should use "python3" not "python"')
+def step_verify_python3_command(context):
+    """Verify commands use python3."""
+    commands_to_check = []
+
+    if hasattr(context, "venv_commands"):
+        commands_to_check.extend(context.venv_commands)
+    elif hasattr(context, "dry_run_commands"):
+        commands_to_check.extend(context.dry_run_commands)
+    elif hasattr(context, "migration_commands"):
+        commands_to_check.extend(context.migration_commands)
+
+    for line_num, line in commands_to_check:
+        assert "python3" in line, f"Line {line_num} should use 'python3': {line}"
+        # Make sure it's not using plain 'python '
+        assert not re.search(
+            r"\bpython(?!3)\s", line
+        ), f"Line {line_num} uses 'python' instead of 'python3': {line}"
+
+
+@then('all commands should use "python3" not "python"')
+def step_verify_all_python3(context):
+    """Verify all Python commands use python3."""
+    # Check that we don't have any plain 'python ' commands
+    for line_num, line in context.python_commands:
+        raise AssertionError(
+            f"Line {line_num} uses 'python' instead of 'python3': {line}"
+        )
+
+
+@then('there should be no instances of "python " without the "3"')
+def step_no_plain_python(context):
+    """Verify no plain python commands exist."""
+    # This checks the entire file for any 'python ' without '3'
+    pattern = r"\bpython(?!3)\s"
+    matches = []
+    for i, line in enumerate(context.readme_lines):
+        if re.search(pattern, line):
+            matches.append((i + 1, line))
+
+    assert (
+        len(matches) == 0
+    ), f"Found {len(matches)} instances of 'python' without '3': {matches}"

--- a/tests/integration/unit/test_readme_validation.py
+++ b/tests/integration/unit/test_readme_validation.py
@@ -1,0 +1,151 @@
+"""Unit tests for README validation."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+class TestReadmeValidation(unittest.TestCase):
+    """Test cases for validating README.md content."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.readme_path = Path("README.md")
+        if self.readme_path.exists():
+            self.readme_content = self.readme_path.read_text()
+            self.readme_lines = self.readme_content.splitlines()
+        else:
+            self.readme_content = ""
+            self.readme_lines = []
+
+    def test_readme_exists(self):
+        """Test that README.md exists in project root."""
+        self.assertTrue(
+            self.readme_path.exists(), "README.md not found in project root"
+        )
+
+    def test_no_bare_python_commands(self):
+        """Test that README doesn't contain bare 'python' commands."""
+        # Pattern to match 'python' followed by space, but not 'python3'
+        pattern = r"\bpython(?!3)\s"
+
+        bare_python_lines = []
+        for i, line in enumerate(self.readme_lines):
+            if re.search(pattern, line):
+                bare_python_lines.append((i + 1, line))
+
+        self.assertEqual(
+            len(bare_python_lines),
+            0,
+            f"Found bare 'python' commands on lines: {bare_python_lines}",
+        )
+
+    def test_python3_used_in_venv_setup(self):
+        """Test that virtual environment setup uses python3."""
+        venv_lines = [
+            (i + 1, line)
+            for i, line in enumerate(self.readme_lines)
+            if "venv" in line and "-m" in line
+        ]
+
+        for line_num, line in venv_lines:
+            self.assertIn(
+                "python3",
+                line,
+                f"Line {line_num} should use 'python3' for venv setup: {line}",
+            )
+
+    def test_python3_used_in_migrate_commands(self):
+        """Test that migrate.py commands use python3."""
+        migrate_lines = [
+            (i + 1, line)
+            for i, line in enumerate(self.readme_lines)
+            if "migrate.py" in line
+        ]
+
+        for line_num, line in migrate_lines:
+            if "python" in line:  # Only check lines that have python commands
+                self.assertIn(
+                    "python3",
+                    line,
+                    f"Line {line_num} should use 'python3' for migrate.py: {line}",
+                )
+
+    def test_all_code_blocks_use_python3(self):
+        """Test that all code blocks with Python commands use python3."""
+        in_code_block = False
+        code_block_lines = []
+
+        for i, line in enumerate(self.readme_lines):
+            if line.strip().startswith("```"):
+                in_code_block = not in_code_block
+            elif in_code_block and "python " in line:
+                code_block_lines.append((i + 1, line))
+
+        for line_num, line in code_block_lines:
+            # Check if it's a bare python command
+            if re.search(r"\bpython(?!3)\s", line):
+                self.fail(
+                    f"Line {line_num} in code block uses "
+                    f"'python' instead of 'python3': {line}"
+                )
+
+    def test_consistency_across_readme(self):
+        """Test that Python command usage is consistent throughout README."""
+        # Count python3 vs python usage
+        python3_count = sum(1 for line in self.readme_lines if "python3" in line)
+        python_pattern = r"\bpython(?!3)\s"
+        python_count = sum(
+            1 for line in self.readme_lines if re.search(python_pattern, line)
+        )
+
+        # If we have any python3 commands, we shouldn't have bare python commands
+        if python3_count > 0:
+            self.assertEqual(
+                python_count,
+                0,
+                f"Inconsistent usage: found {python3_count} 'python3' "
+                f"and {python_count} 'python' commands",
+            )
+
+    def test_installation_section_uses_python3(self):
+        """Test that installation section specifically uses python3."""
+        in_installation = False
+        installation_lines = []
+
+        for i, line in enumerate(self.readme_lines):
+            if "## Installation" in line or "## Setup" in line:
+                in_installation = True
+            elif line.startswith("##") and in_installation:
+                in_installation = False
+            elif in_installation and "python" in line:
+                installation_lines.append((i + 1, line))
+
+        for line_num, line in installation_lines:
+            if re.search(r"\bpython(?!3)\s", line):
+                self.fail(
+                    f"Installation section line {line_num} should use 'python3': {line}"
+                )
+
+    def test_examples_section_uses_python3(self):
+        """Test that examples section uses python3."""
+        in_examples = False
+        example_lines = []
+
+        for i, line in enumerate(self.readme_lines):
+            if "## Usage" in line or "## Examples" in line or "## Example" in line:
+                in_examples = True
+            elif line.startswith("##") and in_examples:
+                in_examples = False
+            elif in_examples and "python" in line:
+                example_lines.append((i + 1, line))
+
+        for line_num, line in example_lines:
+            if re.search(r"\bpython(?!3)\s", line):
+                self.fail(
+                    f"Examples section line {line_num} should use 'python3': {line}"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace all instances of `python` with `python3` in README.md
- Add comprehensive test coverage for README documentation consistency
- Ensures compatibility with systems where Python 3 is explicitly installed as `python3`

## Related Issue
Closes #18

## Changes Made
1. Updated all Python commands in README.md from `python` to `python3`
2. Added BDD integration tests to validate README documentation
3. Added unit tests to ensure Python command consistency

## Test Plan
- [x] Run unit tests: `python3 -m unittest tests.integration.unit.test_readme_validation -v`
- [x] Run integration tests: `cd tests/integration && behave features/readme_documentation.feature`
- [x] All pre-commit hooks pass
- [x] Manual verification of README commands

🤖 Generated with [Claude Code](https://claude.ai/code)