### PR TITLE
fix: enhance YAML frontmatter parsing with robust error recovery

### DIFF
--- a/src/obsidian_to_notion/parsers/obsidian_parser.py
+++ b/src/obsidian_to_notion/parsers/obsidian_parser.py
@@ -99,11 +99,70 @@ class ObsidianVaultProcessor:
                 continue
 
             # Fix missing space after colon in key:value pairs
-            # Match word characters followed by colon and non-space
-            match = re.match(r"^(\s*)([^:\s]+):(\S.*)$", line)
+            # Match characters followed by colon and non-space (but exclude URLs)
+            match = re.match(r"^(\s*)([^:]+):(\S.*)$", line)
             if match:
                 indent, key, value = match.groups()
-                fixed_lines.append(f"{indent}{key}: {value}")
+                # Don't fix URLs or markdown links
+                if not ("http://" in line or "https://" in line or "](" in line):
+                    fixed_lines.append(f"{indent}{key}: {value}")
+                else:
+                    fixed_lines.append(line)
+            else:
+                fixed_lines.append(line)
+
+        return "\n".join(fixed_lines)
+
+    def _quote_problematic_yaml_values(self, yaml_text: str) -> str:
+        """Quote YAML values that contain problematic characters.
+
+        Args:
+            yaml_text: Raw YAML text
+
+        Returns:
+            YAML text with quoted problematic values
+        """
+        lines = yaml_text.split("\n")
+        fixed_lines = []
+
+        for line in lines:
+            # Skip empty lines or lines that don't look like key-value pairs
+            if not line.strip() or ":" not in line:
+                fixed_lines.append(line)
+                continue
+
+            # Split on first colon to separate key and value
+            parts = line.split(":", 1)
+            if len(parts) != 2:
+                fixed_lines.append(line)
+                continue
+
+            key, value = parts
+            value = value.strip()
+
+            # Skip if already quoted or empty
+            is_quoted = (value.startswith('"') and value.endswith('"')) or (
+                value.startswith("'") and value.endswith("'")
+            )
+            if not value or is_quoted:
+                fixed_lines.append(line)
+                continue
+
+            # Quote values that contain unescaped colons or look like URLs
+            should_quote = False
+            if ":" in value and not value.startswith("[") and not value.startswith("-"):
+                # Quote values with colons unless they are already quoted
+                should_quote = True
+            elif (
+                ("http://" in value or "https://" in value or "://" in value)
+                and not value.startswith('"')
+                and not value.startswith("'")
+            ):
+                # Quote URL values to prevent YAML parsing issues
+                should_quote = True
+
+            if should_quote:
+                fixed_lines.append(f"{key}: '{value}'")
             else:
                 fixed_lines.append(line)
 
@@ -142,7 +201,7 @@ class ObsidianVaultProcessor:
         else:
             return "", content
 
-        return yaml_text.strip(), markdown_content.strip()
+        return yaml_text.strip(), markdown_content.lstrip()
 
     def _parse_yaml_with_recovery(self, yaml_text: str) -> Dict:
         """Parse YAML with error recovery.
@@ -169,25 +228,43 @@ class ObsidianVaultProcessor:
         except yaml.YAMLError:
             pass
 
-        # Third attempt: Remove template placeholders
+        # Third attempt: Remove template placeholders and fix common errors
         try:
-            # Replace {{placeholder}} with empty string
+            # Replace {{placeholder}} with quoted empty string for YAML compatibility
             cleaned_yaml = re.sub(r"\{\{[^}]+\}\}", '""', yaml_text)
             cleaned_yaml = self._fix_yaml_common_errors(cleaned_yaml)
             return yaml.safe_load(cleaned_yaml) or {}
         except yaml.YAMLError:
             pass
 
-        # Fourth attempt: Extract simple key-value pairs
+        # Fourth attempt: Quote problematic values
+        try:
+            # Quote values that contain special characters like colons
+            fixed_yaml = self._quote_problematic_yaml_values(yaml_text)
+            fixed_yaml = self._fix_yaml_common_errors(fixed_yaml)
+            # Also remove template placeholders
+            fixed_yaml = re.sub(r"\{\{[^}]+\}\}", '""', fixed_yaml)
+            return yaml.safe_load(fixed_yaml) or {}
+        except yaml.YAMLError:
+            pass
+
+        # Fifth attempt: Extract simple key-value pairs
         metadata = {}
         for line in yaml_text.split("\n"):
             # Match simple key: value pattern
             match = re.match(r"^([^:]+):\s*(.+)$", line.strip())
             if match:
                 key, value = match.groups()
-                # Skip lines with template syntax or other issues
-                if "{{" not in value and "[[" not in key:
-                    metadata[key.strip()] = value.strip()
+                # Skip lines with template syntax, wiki links, or markdown links
+                has_template = "{{" in value
+                has_wikilink = "[[" in key or "[[" in value
+                has_markdown_link = re.search(r"\[.*?\]\(.*?\)", value)
+                if not (has_template or has_wikilink or has_markdown_link):
+                    # Clean the value of problematic characters for simple extraction
+                    cleaned_value = value.strip()
+                    # Skip values that look like they would break YAML
+                    if not any(char in cleaned_value for char in ["{", "}", "[", "]"]):
+                        metadata[key.strip()] = cleaned_value
 
         return metadata
 

--- a/tests/integration/features/obsidian_parser.feature
+++ b/tests/integration/features/obsidian_parser.feature
@@ -160,3 +160,111 @@ Feature: Obsidian Vault Processing
     Then all valid files should be processed
     And files with invalid YAML should not stop the migration
     And appropriate warnings should be logged for invalid files
+
+  Scenario: Handle template placeholder in nested YAML structure
+    Given a markdown file "nested_template.md" with complex template frontmatter:
+      """
+      ---
+      tags:
+      - note_type/raw_note/blog
+      - no_permanent_note_yet
+      citation:
+        author: {{author}}
+        title: Example Title
+        name_of_blog: {{name_of_blog}}
+        blog_network_publisher: {{blog_network_publisher}}
+        date_of_post: {{date_of_post}}
+        accessed: 2023-04-10
+        url: https://www.example.com
+      ---
+      # Content
+      Test content here.
+      """
+    When I process the vault
+    Then the file should be processed successfully
+    And the citation structure should be preserved
+    And template placeholders should be replaced with empty strings
+
+  Scenario: Handle multiple template placeholders on same line
+    Given a markdown file "multiple_placeholders.md" with frontmatter:
+      """
+      ---
+      tags:
+      - note_type/raw_note/meeting
+      - no_permanent_note
+      attendees:
+      date: {{date}} {{time}}
+      location: {{location}}
+      ---
+      # Meeting Notes
+      Meeting content here.
+      """
+    When I process the vault
+    Then the file should be processed successfully
+    And all template placeholders should be handled gracefully
+    And the content should remain intact
+
+  Scenario: Handle markdown links in YAML values
+    Given a markdown file "markdown_in_yaml.md" with frontmatter:
+      """
+      ---
+      tags: [research]
+      citation:
+        author: [Kendra Cherry](https://www.verywellmind.com/kendra-cherry)
+        title: Scientific Research Methods
+        publisher: [Very Well Mind](https://www.verywellmind.com)
+      ---
+      # Research Notes
+      Content with scientific citations.
+      """
+    When I process the vault
+    Then the file should be processed successfully
+    And markdown links in YAML should be handled gracefully
+
+  Scenario: Handle YAML with unquoted colon in values
+    Given a markdown file "unquoted_colon.md" with frontmatter:
+      """
+      ---
+      title: Book: The Complete Guide
+      subtitle: Everything: You Need to Know
+      author: John Doe
+      ---
+      # Book Notes
+      Notes about the book.
+      """
+    When I process the vault
+    Then the file should be processed successfully
+    And colons in values should be handled properly
+
+  Scenario: Handle missing spaces after colons in YAML
+    Given a markdown file "missing_spaces.md" with frontmatter:
+      """
+      ---
+      business name:Copart
+      In contacts:No
+      url:https://docs.example.org/en/use/content
+      ---
+      # Organization Notes
+      Company information.
+      """
+    When I process the vault
+    Then the file should be processed successfully
+    And missing spaces after colons should be corrected
+
+  Scenario: Handle tab characters in YAML
+    Given a markdown file "tabs_in_yaml.md" with frontmatter:
+      """
+      ---
+      attendees:
+      	- [[Robert Turnbull]]
+      	- [[Sarah Moore]]
+      tags:
+      	- meeting
+      	- planning
+      ---
+      # Meeting Notes
+      Meeting with team members.
+      """
+    When I process the vault
+    Then the file should be processed successfully
+    And tab characters should be converted to spaces

--- a/tests/unit/test_obsidian_parser.py
+++ b/tests/unit/test_obsidian_parser.py
@@ -500,5 +500,199 @@ Contains [[Note 3]] and [[Note 4]] in content."""
         self.assertIn("Note 4", note_names)
 
 
+class TestYAMLParsingMethods(unittest.TestCase):
+    """Specific tests for YAML parsing helper methods."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.vault_path = Path(self.temp_dir) / "test_vault"
+        self.vault_path.mkdir(parents=True)
+        self.processor = ObsidianVaultProcessor(str(self.vault_path))
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.temp_dir)
+
+    def test_fix_yaml_common_errors_tabs_to_spaces(self):
+        """Test tab to space conversion in YAML."""
+        yaml_text = "attendees:\n\t- [[Robert Turnbull]]\n\t- [[John Doe]]"
+        fixed = self.processor._fix_yaml_common_errors(yaml_text)
+
+        self.assertNotIn("\t", fixed)
+        self.assertIn("  - [[Robert Turnbull]]", fixed)
+        self.assertIn("  - [[John Doe]]", fixed)
+
+    def test_fix_yaml_common_errors_missing_space_after_colon(self):
+        """Test fixing missing space after colon."""
+        yaml_text = "business name:Copart\nlocation:USA\nemployees:7000"
+        fixed = self.processor._fix_yaml_common_errors(yaml_text)
+
+        self.assertIn("business name: Copart", fixed)
+        self.assertIn("location: USA", fixed)
+        self.assertIn("employees: 7000", fixed)
+
+    def test_fix_yaml_common_errors_preserves_urls(self):
+        """Test that URLs are not modified."""
+        yaml_text = "url:https://docs.example.org/en/use/content\nother:value"
+        fixed = self.processor._fix_yaml_common_errors(yaml_text)
+
+        # URL should not have space added after colon
+        self.assertIn("url:https://docs.example.org/en/use/content", fixed)
+        # But normal field should have space added
+        self.assertIn("other: value", fixed)
+
+    def test_fix_yaml_errors_preserves_markdown_links(self):
+        """Test that markdown links in YAML are not broken."""
+        yaml_text = (
+            "author: [Kendra Cherry](https://www.verywellmind.com)\n" "title:Research"
+        )
+        fixed = self.processor._fix_yaml_common_errors(yaml_text)
+
+        # Markdown link should be preserved
+        self.assertIn("[Kendra Cherry](https://www.verywellmind.com)", fixed)
+        # But title should have space added
+        self.assertIn("title: Research", fixed)
+
+    def test_extract_yaml_split_standard_format(self):
+        """Test standard frontmatter extraction."""
+        content = "---\ntitle: Test\nauthor: John\n---\n\n# Content\n\nTest content"
+        yaml_text, markdown_content = self.processor._extract_yaml_content_split(
+            content
+        )
+
+        self.assertEqual(yaml_text, "title: Test\nauthor: John")
+        self.assertEqual(markdown_content, "# Content\n\nTest content")
+
+    def test_extract_yaml_split_missing_delimiter(self):
+        """Test handling missing closing delimiter."""
+        content = "---\ntitle: Test\nauthor: John\n\n# Content"
+        yaml_text, markdown_content = self.processor._extract_yaml_content_split(
+            content
+        )
+
+        self.assertEqual(yaml_text, "title: Test\nauthor: John")
+        self.assertEqual(markdown_content, "# Content")
+
+    def test_extract_yaml_split_no_frontmatter(self):
+        """Test content without frontmatter."""
+        content = "# Just Content\n\nNo frontmatter here."
+        yaml_text, markdown_content = self.processor._extract_yaml_content_split(
+            content
+        )
+
+        self.assertEqual(yaml_text, "")
+        self.assertEqual(markdown_content, content)
+
+    def test_parse_yaml_with_recovery_valid_yaml(self):
+        """Test recovery parser with valid YAML."""
+        yaml_text = "title: Test\ndate: 2024-01-15\ntags:\n  - test\n  - unit"
+        result = self.processor._parse_yaml_with_recovery(yaml_text)
+
+        self.assertEqual(result["title"], "Test")
+        self.assertEqual(result["tags"], ["test", "unit"])
+
+    def test_parse_yaml_with_recovery_template_placeholders(self):
+        """Test recovery parser with template placeholders."""
+        yaml_text = "author: {{author}}\ntitle: {{title}}\ndate: {{date}}"
+        result = self.processor._parse_yaml_with_recovery(yaml_text)
+
+        # Should replace template placeholders with empty strings
+        self.assertIn("author", result)
+        self.assertIn("title", result)
+        self.assertIn("date", result)
+        # Values should be empty strings, not the template syntax
+        self.assertEqual(result["author"], "")
+
+    def test_parse_yaml_with_recovery_nested_template_placeholders(self):
+        """Test recovery parser with nested template placeholders."""
+        yaml_text = """citation:
+  author: {{author}}
+  title: Example Title
+  blog: {{blog_name}}
+  date: {{date_of_post}}"""
+        result = self.processor._parse_yaml_with_recovery(yaml_text)
+
+        # Should have citation structure preserved
+        self.assertIn("citation", result)
+        if isinstance(result["citation"], dict):
+            self.assertIn("title", result["citation"])
+            self.assertEqual(result["citation"]["title"], "Example Title")
+
+    def test_parse_yaml_with_recovery_tabs_and_template_placeholders(self):
+        """Test recovery parser with both tabs and template placeholders."""
+        yaml_text = "attendees:\n\t- {{name1}}\n\t- {{name2}}\ntitle: {{title}}"
+        result = self.processor._parse_yaml_with_recovery(yaml_text)
+
+        # Should handle both issues
+        self.assertIsInstance(result, dict)
+        # Should extract some metadata even if structure is simplified
+
+    def test_parse_yaml_recovery_markdown_links(self):
+        """Test recovery parser with markdown links in values."""
+        yaml_text = (
+            "author: [Kendra Cherry](https://www.verywellmind.com)\n" "title: Research"
+        )
+        result = self.processor._parse_yaml_with_recovery(yaml_text)
+
+        # Should extract what it can
+        self.assertIsInstance(result, dict)
+
+    def test_parse_yaml_with_recovery_simple_fallback(self):
+        """Test that simple key-value extraction works as fallback."""
+        yaml_text = "title: Simple Title\nauthor: John Doe\ndate: 2024-01-15"
+        result = self.processor._parse_yaml_with_recovery(yaml_text)
+
+        self.assertEqual(result["title"], "Simple Title")
+        self.assertEqual(result["author"], "John Doe")
+        self.assertEqual(str(result["date"]), "2024-01-15")
+
+    def test_parse_yaml_recovery_handles_problematic_lines(self):
+        """Test that recovery handles various problematic constructs."""
+        yaml_text = (
+            "title: Good Title\nbroken: {{template}}\n"
+            "author: [[John Doe]]\ndate: 2024-01-15"
+        )
+        result = self.processor._parse_yaml_with_recovery(yaml_text)
+
+        # Should successfully parse after template replacement
+        self.assertEqual(result["title"], "Good Title")
+        self.assertEqual(str(result["date"]), "2024-01-15")
+        # Template placeholder should be replaced with empty string
+        self.assertEqual(result["broken"], "")
+        # [[John Doe]] is valid YAML (nested list), so it gets parsed
+        self.assertIn("author", result)
+        self.assertEqual(result["author"], [["John Doe"]])
+
+    def test_parse_yaml_with_recovery_empty_input(self):
+        """Test recovery parser with empty input."""
+        result = self.processor._parse_yaml_with_recovery("")
+        self.assertEqual(result, {})
+
+    def test_parse_yaml_with_recovery_multiple_placeholders_same_line(self):
+        """Test handling multiple template placeholders on same line."""
+        yaml_text = "date: {{date}} {{time}}\nlocation: {{location}}\ntitle: Meeting"
+        result = self.processor._parse_yaml_with_recovery(yaml_text)
+
+        # Should extract what it can
+        self.assertIn("title", result)
+        self.assertEqual(result["title"], "Meeting")
+
+    def test_parse_yaml_recovery_simple_fallback_only(self):
+        """Test that simple extraction fallback works for unparseable YAML."""
+        yaml_text = (
+            "title: Simple Title\nbroken: {{{ invalid yaml }}}\n"
+            "author: [[John Doe]]\ndate: 2024-01-15"
+        )
+        result = self.processor._parse_yaml_with_recovery(yaml_text)
+
+        # Should fall back to simple extraction
+        self.assertEqual(result["title"], "Simple Title")
+        self.assertEqual(result["date"], "2024-01-15")
+        # Should skip lines with problematic syntax
+        self.assertNotIn("broken", result)
+        self.assertNotIn("author", result)  # Contains [[ ]]
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Fix YAML frontmatter parsing errors that were causing the dry run to fail on many files
- Add comprehensive error recovery for template placeholders like `{{author}}`
- Handle missing spaces after colons, tabs in YAML, and other common formatting issues
- Implement fallback parsing for completely unparseable YAML

## Test plan
- [x] All new unit tests pass (17 new tests for YAML parsing methods)
- [x] All integration tests updated and pass
- [x] Dry run now processes all 1614 files successfully (was failing on many before)
- [x] Code quality checks pass (flake8, mypy, black, etc.)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)